### PR TITLE
Docs: add research reports

### DIFF
--- a/docs/reports/2026-02-21-claude-mem-analysis.md
+++ b/docs/reports/2026-02-21-claude-mem-analysis.md
@@ -1,0 +1,172 @@
+# claude-mem Memory Architecture Analysis
+
+Repo analyzed: https://github.com/thedotmack/claude-mem (local clone)
+
+## Architecture Diagram (text)
+
+```text
+Claude/Cursor/OpenClaw lifecycle events
+  -> CLI adapters normalize hook payloads
+  -> Hook handlers (session-init, observation, summarize, session-complete)
+  -> Worker HTTP API (:37777)
+  -> SessionManager + PendingMessageStore queue (SQLite)
+  -> Memory agent (Claude SDK / Gemini / OpenRouter) consumes queued events
+  -> XML output parser (observations + summary)
+  -> Atomic write to SQLite (observations/session_summaries/user_prompts)
+  -> Async sync to Chroma (vector docs)
+  -> Retrieval path:
+       search/timeline/get_observations/save_memory MCP tools
+       -> worker search orchestrator
+       -> Chroma semantic + SQLite metadata hydrate/fallback
+  -> Next session context injection from SQLite observations/summaries
+```
+
+## Key Files and What They Do
+
+- `src/services/sqlite/SessionStore.ts`: Primary schema + migrations + writes for `sdk_sessions`, `observations`, `session_summaries`, `user_prompts`, `pending_messages`.
+- `src/services/sqlite/SessionSearch.ts`: SQLite filter queries; keeps FTS tables but current code comments mark text search as deprecated in favor of Chroma for query text.
+- `src/services/worker/http/routes/SessionRoutes.ts`: API endpoints for init/observation/summarize/complete; privacy/tag stripping + skip-tools logic.
+- `src/services/worker/SessionManager.ts`: Event-driven queueing, persistent pending message flow.
+- `src/services/queue/SessionQueueProcessor.ts`: Claim-confirm queue iterator + stale processing self-heal.
+- `src/services/worker/SDKAgent.ts`: Main auto-memory loop using Anthropic Agent SDK (or provider variants) to convert tool events into structured memory XML.
+- `src/sdk/prompts.ts` + `plugin/modes/code.json`: Memory extraction/summarization prompts and taxonomy (types/concepts).
+- `src/sdk/parser.ts`: XML parser for `<observation>` and `<summary>` blocks.
+- `src/services/worker/agents/ResponseProcessor.ts`: Atomic store of parsed outputs; async Chroma sync + SSE broadcast.
+- `src/services/sync/ChromaSync.ts`: Semantic indexing/querying via Chroma MCP bridge; granular field-level vector docs.
+- `src/services/worker/search/SearchOrchestrator.ts` + strategies: retrieval strategy selection and fallback logic.
+- `src/services/context/ContextBuilder.ts` + `src/services/context/ObservationCompiler.ts`: Context injection from recent observations/summaries.
+- `src/services/worker/http/routes/MemoryRoutes.ts`: `save_memory` manual memory insert endpoint.
+- `src/servers/mcp-server.ts`: MCP tools (`search`, `timeline`, `get_observations`, `save_memory`) mapped to worker HTTP API.
+
+## 1) Data Model
+
+### System of record
+- **SQLite** at `~/.claude-mem/claude-mem.db` in WAL mode.
+
+### Core tables
+- `sdk_sessions`: maps `content_session_id` to `memory_session_id`, tracks session metadata.
+- `observations`: structured units (`type`, `title`, `subtitle`, `facts[]`, `narrative`, `concepts[]`, `files_read[]`, `files_modified[]`, `prompt_number`, timestamps).
+- `session_summaries`: summary checkpoint fields (`request`, `investigated`, `learned`, `completed`, `next_steps`, `notes`, files).
+- `user_prompts`: cleaned prompt text per prompt number.
+- `pending_messages`: durable queue for observation/summarize tasks.
+
+### Search/index sidecar
+- **Chroma vector DB** for semantic retrieval (collection names `cm__*`), with metadata including `sqlite_id`, `doc_type`, `project`.
+- FTS5 virtual tables still maintained, but latest code path treats query-text search as Chroma-first and SQLite as metadata/filter path.
+
+## 2) How Summarization Works and Is Stored
+
+1. `Stop` hook calls `/api/sessions/summarize` with `last_assistant_message`.
+2. Worker enqueues summarize task in `pending_messages`.
+3. Memory agent receives generated prompt from `buildSummaryPrompt(...)` (XML schema required).
+4. Parser extracts `<summary>`.
+5. `ResponseProcessor` performs **atomic transaction** via `storeObservations(...)` to write observations + optional summary once.
+6. Summary row saved in `session_summaries`; optionally indexed to Chroma (`doc_type=session_summary`).
+
+Important design choice: parser stores summaries even with partial/missing fields (nullable normalized to empty strings before storage), favoring write-through over strict validation.
+
+## 3) Retrieval: Keyword, Vector, or Hybrid?
+
+- **Primary for query text:** Vector semantic (Chroma).
+- **SQLite path:** metadata filters (project/type/concept/files/date), hydration by IDs, timeline queries.
+- **Hybrid:** metadata prefilter in SQLite + semantic ranking in Chroma + intersection + hydrate.
+
+So today it is effectively **vector-first with SQL-filter/hydration**, not classic keyword-first.
+
+## 4) Automatic Fact Extraction / Auto-memory
+
+### Yes, it does auto-memory
+- Every eligible `PostToolUse` event is queued.
+- Agent converts tool input/output into structured `<observation>` XML.
+- Parser stores extracted fields automatically.
+- `Stop` creates summary checkpoints automatically.
+
+### Manual memory also exists
+- `save_memory` endpoint/tool inserts a synthetic `discovery` observation.
+
+### If asking “does it extract stable user facts/profile memory?”
+- **Not really.** It extracts *work observations* from tool activity rather than explicit durable user/profile facts with confidence/conflict handling.
+
+### What would be needed for stronger auto-memory
+- Dedicated fact schema (`entity`, `attribute`, `value`, `source`, `confidence`, `valid_from/to`, `status`).
+- Idempotent upsert/dedup at fact level (hash + semantic near-duplicate checks).
+- Contradiction resolution and fact aging.
+- Separate pipelines for procedural/project memory vs personal/user facts.
+- Quality gates (classifier/rules) before persisting long-lived facts.
+
+## 5) Claude-specific vs General
+
+### Claude-specific
+- Hook lifecycle integration and formats geared to Claude Code (`session_id`, transcript path, hook events).
+- Primary auto-memory engine defaults to Anthropic Agent SDK (`SDKAgent`).
+- Plugin packaging/modes around Claude ecosystem.
+
+### General/reusable
+- Storage model (SQLite schema + pending queue + observation/summary abstractions).
+- Provider abstraction exists (`GeminiAgent`, `OpenRouterAgent`) with shared `ResponseProcessor`.
+- Retrieval/search architecture and MCP wrapper are generally reusable.
+- Privacy tag stripping, skip-tools filtering, queue orchestration, context rendering are model-agnostic.
+
+## 6) Strengths vs Weaknesses
+
+## Strengths (why summaries often feel good)
+- Strong prompt structure + constrained XML output taxonomy.
+- Continuous event-driven capture from tool stream, not just end-of-session recap.
+- Durable queue + atomic storage path improves data survival.
+- Progressive disclosure retrieval flow (`search -> timeline -> get_observations`) is token-efficient.
+- Granular vector docs (facts/narrative/summary fields split) can improve semantic recall.
+
+## Weaknesses (why auto-memory can feel not amazing)
+- Over-capture/duplication risk in high-throughput sessions (multiple open issues e.g. #1158, #1061, #1137).
+- Heavy operational complexity around worker/process/chroma lifecycle (many reliability issues).
+- Vector dependency fragility (Windows/chroma/python/packaging issues; e.g. #1199, #1196, #1185, #1146).
+- Limited dedup/importance scoring in core auto pipeline; “save everything” bias can reduce precision.
+- Recency filtering (90-day window) can hide older but relevant knowledge.
+- Not designed as canonical fact graph; mostly event summaries/observations.
+
+## 7) Replicating Good Parts in Mycel (Python + Temporal + Postgres)
+
+## Feasibility
+- **Good parts are very replicable.** Most value is in pipeline design, prompt schema, and retrieval flow, not Claude-specific APIs.
+
+## Suggested Mycel architecture (Postgres as SoR)
+
+- Use Postgres tables:
+  - `sessions`, `events`, `observations`, `session_summaries`, `user_prompts`, `pending_tasks`, `facts` (new).
+- Use `pgvector` for semantic search (replace Chroma sidecar).
+- Keep JSONB arrays (`facts`, `concepts`, `files_*`) with GIN indexes.
+- Temporal workflows:
+  - `IngestEventWorkflow` (tool events/user prompts)
+  - `ObservationExtractionWorkflow` (LLM XML/JSON extraction)
+  - `SummaryWorkflow` (checkpoint summary)
+  - `IndexingWorkflow` (embeddings + vector upsert)
+  - `RecoveryWorkflow` (stuck task healing, dedup sweeps)
+- Retrieval API in 3 layers (same winning pattern): index -> timeline -> hydrate.
+
+## Effort estimate (rough)
+- 1-2 weeks: core ingestion + observation/summary extraction + Postgres schema + API.
+- +1 week: high-quality retrieval (hybrid filters + vector ranking + timeline).
+- +1-2 weeks: hardening (dedup, retries, temporal recovery policies, quality metrics).
+
+## What to copy directly
+- XML/structured extraction contract with strict parser.
+- Durable queue semantics (claim-confirm equivalent in Temporal activity state).
+- Progressive disclosure retrieval UX.
+- Privacy/tag filtering at ingestion edge.
+
+## What to improve in Mycel
+- Postgres-first single-store (avoid dual-store drift/ops burden).
+- First-class dedup/idempotency keys at ingest and observation levels.
+- Fact table with confidence/conflict resolution for true long-term memory.
+- Better scoring (importance/novelty/redundancy) before persistence.
+- Explicit SLO monitoring: duplicate rate, stuck-task rate, retrieval precision.
+
+## Issue Scan Notes (known limitations)
+
+Recent issues indicate memory quality is often constrained more by runtime reliability than schema design:
+- Duplicate/overcapture: #1158, #1061, #1137
+- Observation pipeline failures: #1091, #1058
+- Chroma/search reliability and platform issues: #1199, #1196, #1185, #1146, #1123, #1110
+- Resource/process leakage affecting stability: #1089, #1077, #1068
+
+This explains why architecture is conceptually strong, but “auto-memory quality” can degrade in practice.

--- a/docs/reports/2026-02-21-llm-memory-systems-survey.md
+++ b/docs/reports/2026-02-21-llm-memory-systems-survey.md
@@ -1,0 +1,218 @@
+# LLM Memory Systems Survey (beyond Mem0 + raw Postgres/Qdrant)
+
+Date: February 22, 2026
+Scope: Systems/patterns for (a) summarizing conversation history into usable long-term memory and (b) automatic memory extraction robust to negation, conditionals, and temporal validity.
+Target context: Mycel (single user, Temporal workflows, cost-sensitive).
+
+## Shortlist (8 options)
+
+## 1) Zep Cloud (managed) / Graphiti-backed memory service
+- What it is + maturity:
+  - Managed agent memory/context assembly product from Zep.
+  - Mature and actively used in production; Zep and Graphiti benchmarked in the Zep paper (2025) and Graphiti has large OSS adoption.
+- How it stores:
+  - Temporal knowledge graph (entities/edges/episodes), plus hybrid retrieval (semantic + full-text + graph/time-aware search).
+  - Managed API, no direct infra ops required.
+- Summarization approach:
+  - Builds user/context blocks from graph state; supports user-summary customization and context assembly APIs.
+  - Summarization is graph-derived rather than only rolling transcript compression.
+- Auto memory extraction approach:
+  - Extracts facts/relationships from incoming episodes/messages and updates graph incrementally.
+  - Can ingest unstructured chat and structured business JSON.
+- Negation / conditional / temporal support:
+  - Strong temporal validity support (fact lifecycle + invalidation, historical state tracking).
+  - Negation and state flips are represented as relationship changes over time.
+  - Conditionals are partially supported (if-then intent is often stored as qualified fact; complex logic still app-defined).
+- Python friendliness:
+  - Strong (Python SDK + ecosystem integrations).
+- Fit for Mycel:
+  - Good if you want fastest time-to-value.
+  - Tradeoff: recurring vendor cost for one-user scenario may be high versus self-hosted pattern.
+  - Fit score: 4/5.
+
+## 2) Graphiti OSS (self-hosted temporal KG framework)
+- What it is + maturity:
+  - Open-source temporal knowledge graph framework from Zep team.
+  - Very active OSS project as of 2026, Apache-2.0.
+- How it stores:
+  - Graph database-backed temporal graph model (entities, edges, episodes; bi-temporal semantics in ecosystem implementations).
+- Summarization approach:
+  - Summaries are generated from graph neighborhoods/episodes (you control prompts and assembly).
+- Auto memory extraction approach:
+  - Incremental entity/relation extraction with schema reuse and graph updates on each new episode.
+- Negation / conditional / temporal support:
+  - Temporal: first-class.
+  - Negation/changes: handled via edge updates/invalidation and historical edges.
+  - Conditional: needs schema/prompt design (not a built-in logic engine).
+- Python friendliness:
+  - Strong (Python-first OSS with docs/examples).
+- Fit for Mycel:
+  - Excellent for cost-sensitive single-user if you can run graph infra and extraction jobs.
+  - Pairs well with Temporal workflows for asynchronous extraction/compaction.
+  - Fit score: 5/5.
+
+## 3) Letta (MemGPT-style architecture)
+- What it is + maturity:
+  - Production framework from MemGPT creators; MemGPT-style memory hierarchy (core + recall + archival).
+  - Good maturity for agent products.
+- How it stores:
+  - Core memory blocks (in-context), recall memory (conversation logs/search), archival memory (often vector DB), optional local memory filesystem.
+- Summarization approach:
+  - Mix of always-visible core blocks and archival retrieval; memory edits can be agent-driven and asynchronous (sleeptime).
+- Auto memory extraction approach:
+  - Tool-mediated memory updates (`memory_*`, archival tools, conversation search tools); can auto-update from interaction.
+- Negation / conditional / temporal support:
+  - Better than plain vector memory because editable memory blocks + recall by date.
+  - Temporal support is moderate (date search, hierarchy) but not as explicit as temporal KG fact validity.
+  - Conditional semantics depend on prompt/tools; no guaranteed formal conditional model.
+- Python friendliness:
+  - Strong.
+- Fit for Mycel:
+  - Very good for assistant-style memory with less custom architecture work.
+  - For strict temporal truth maintenance, may still need a fact layer on top.
+  - Fit score: 4/5.
+
+## 4) LangGraph + LangChain long-term memory (store + checkpointer + profile/collection patterns)
+- What it is + maturity:
+  - General agent orchestration framework with thread persistence, cross-thread stores, TTLs, and memory design patterns.
+  - Very mature ecosystem.
+- How it stores:
+  - Checkpointer (thread state) + memory store (JSON documents in namespaces), with optional semantic indexing.
+  - Can be backed by DB implementations in production.
+- Summarization approach:
+  - User-defined: profile memory (continuously updated schema) or collection memory (append/retrieve); can run on hot path or background jobs.
+- Auto memory extraction approach:
+  - Usually implemented via extraction nodes/tools; Trustcall-style JSON patching improves structured updates.
+- Negation / conditional / temporal support:
+  - Temporal supported via TTL/persistence strategy and explicit fields; not automatic truth maintenance.
+  - Negation/conditional quality depends on extraction schema/prompts + patch validation.
+- Python friendliness:
+  - Excellent.
+- Fit for Mycel:
+  - Excellent for Temporal-workflow alignment (clear node-based extraction/summarization jobs).
+  - Most cost-controllable if you keep schemas narrow and background updates batched.
+  - Fit score: 5/5.
+
+## 5) LlamaIndex Memory (new `Memory` class + chat stores + memory blocks)
+- What it is + maturity:
+  - LlamaIndex-native memory abstractions; older buffers deprecated in favor of unified `Memory`.
+  - Mature in retrieval ecosystem; memory API evolving but practical.
+- How it stores:
+  - Short-term FIFO chat queue + optional long-term memory blocks; pluggable chat stores (in-memory/file/DB-backed via integrations).
+- Summarization approach:
+  - Token-based flushing from short-term to long-term; optional summarization/compression strategies.
+- Auto memory extraction approach:
+  - Long-term blocks can process flushed messages for extraction; vector memory and retrieval can be combined.
+- Negation / conditional / temporal support:
+  - Baseline support unless you design typed memory schemas + time metadata.
+  - No strong built-in temporal truth model; requires custom extraction and conflict handling.
+- Python friendliness:
+  - Excellent.
+- Fit for Mycel:
+  - Good if you already use LlamaIndex stack.
+  - For robust temporal/negation correctness, needs extra policy layer.
+  - Fit score: 3.5/5.
+
+## 6) Haystack conversational memory pattern (ChatMessageStore + retrievers + custom extraction pipeline)
+- What it is + maturity:
+  - Haystack offers composable components; conversational memory primitives exist but parts are in experimental package.
+  - Good core maturity, memory-specific pieces less opinionated.
+- How it stores:
+  - ChatMessageStore + retrievers; plus document stores (including pgvector integrations).
+- Summarization approach:
+  - Mostly custom pipeline stage (LLM summarizer component) rather than opinionated built-in long-term memory lifecycle.
+- Auto memory extraction approach:
+  - Tool/agent loops can call extraction components and write structured docs/messages.
+- Negation / conditional / temporal support:
+  - Depends on your extraction schema; no first-class temporal fact validity model.
+- Python friendliness:
+  - Strong.
+- Fit for Mycel:
+  - Decent if already on Haystack; otherwise more plumbing for memory correctness.
+  - Fit score: 3/5.
+
+## 7) Event-sourced Fact Store pattern (custom, Temporal-native)
+- What it is + maturity:
+  - Architecture pattern (not a single library): append immutable memory events, materialize latest facts/profiles asynchronously.
+  - Very mature pattern in distributed systems, highly compatible with Temporal.
+- How it stores:
+  - Append-only event log (SQL/table/topic), projections for current profile and retrieval index (vector/FTS optional), plus validity windows (`valid_from`, `valid_to`, `supersedes`).
+- Summarization approach:
+  - Periodic workflow compaction into profile summaries and episodic digests.
+  - Multi-resolution summaries (daily/weekly/entity-specific) are straightforward.
+- Auto memory extraction approach:
+  - Extraction worker emits typed events: `fact_asserted`, `fact_negated`, `preference_changed`, `intent_with_condition`, `expired`.
+  - Deterministic projection logic resolves contradictions.
+- Negation / conditional / temporal support:
+  - Strongest if designed well: explicit event types and validity intervals make negation/conditionals/temporal first-class.
+- Python friendliness:
+  - Excellent (your code, your schema).
+- Fit for Mycel:
+  - Best long-term fit for correctness + cost control (1 user).
+  - Initial engineering cost higher than turnkey frameworks.
+  - Fit score: 5/5.
+
+## 8) Recency-aware RAG memory pattern (time-weighted retrieval + temporal metadata filters)
+- What it is + maturity:
+  - Pattern combining vector retrieval with recency scoring and time filters; available in LangChain via time-weighted retriever concepts and widely reproducible.
+  - Mature as a pattern, moderate as “productized memory system”.
+- How it stores:
+  - Usually vector store + metadata (`timestamp`, `expires_at`, `source`, `confidence`, `negated_by`).
+- Summarization approach:
+  - Rolling summary + selective recall (query-dependent) with recency-biased ranking.
+- Auto memory extraction approach:
+  - LLM extraction into small memory documents keyed by entity/topic; background dedupe/merge.
+- Negation / conditional / temporal support:
+  - Temporal recency is good.
+  - True negation/conditional handling is only moderate unless you add explicit conflict-resolution rules and validity fields.
+- Python friendliness:
+  - Excellent.
+- Fit for Mycel:
+  - Low-cost and simple to start, but easy to get subtle contradictions over long horizons.
+  - Fit score: 3.5/5.
+
+## Recommended direction for Mycel
+
+1. Primary recommendation: Option 7 (Event-sourced Fact Store) + Option 8 retrieval layer.
+- Why: best control over negation/conditional/temporal correctness, cheap at 1-user scale, native fit with Temporal workflows.
+
+2. Fastest robust alternative: Option 2 (Graphiti OSS).
+- Why: gives temporal memory semantics out of the box with less custom logic than pure event-sourcing.
+
+3. If you want minimal infra effort: Option 1 (Zep managed).
+- Why: strong quality and temporal handling, but likely overkill on recurring cost for a single user.
+
+## Practical extraction schema (works across options)
+Use typed memory records/events instead of plain “fact text”:
+- `entity_id`
+- `attribute`
+- `value`
+- `polarity` (`asserted` | `negated`)
+- `condition` (nullable expression, e.g. `if_traveling=true`)
+- `valid_from`
+- `valid_to` (nullable)
+- `confidence`
+- `source_turn_id`
+- `supersedes_record_id` (nullable)
+
+This schema is the key lever for correctly handling negation, conditionality, and temporal validity in any framework.
+
+## Sources
+- Zep paper (arXiv): https://arxiv.org/abs/2501.13956
+- Zep Graphiti OSS repo: https://github.com/getzep/graphiti
+- Zep docs (memory/graph retrieval): https://help.getzep.com/docs
+- Zep Mem0 migration capability table: https://help.getzep.com/mem0-to-zep
+- Letta memory management: https://docs.letta.com/concepts/memory-management
+- Letta MemGPT architecture: https://docs.letta.com/guides/agents/architectures/memgpt
+- MemGPT paper (arXiv): https://arxiv.org/abs/2310.08560
+- LlamaIndex memory guide: https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/memory/
+- LlamaIndex chat stores: https://docs.llamaindex.ai/en/stable/module_guides/storing/chat_stores/
+- LangGraph memory (Python): https://docs.langchain.com/oss/python/langgraph/add-memory
+- LangGraph memory overview (profile/collection patterns): https://docs.langchain.com/oss/javascript/langgraph/memory
+- LangGraph TTL configuration: https://docs.langchain.com/langgraph-platform/configure-ttl
+- Trustcall (structured extraction/patching): https://github.com/hinthornw/trustcall
+- Haystack ChatMessageStore API: https://docs.haystack.deepset.ai/reference/experimental-chatmessage-store-api
+- Haystack ChatMessageRetriever API: https://docs.haystack.deepset.ai/reference/experimental-retrievers-api
+- LangChain time-weighted retriever source docs: https://api.python.langchain.com/en/latest/_modules/langchain/retrievers/time_weighted_retriever.html
+- Temporal durable execution overview: https://temporal.io/
+

--- a/docs/reports/2026-02-21-mycel-memory-research.md
+++ b/docs/reports/2026-02-21-mycel-memory-research.md
@@ -1,0 +1,475 @@
+# Mycel Memory Alternatives Research (Feb 21, 2026)
+
+## Executive summary
+Mycel’s hardest problem is not just storage or vector search. It is **high-fidelity fact extraction with logic** (negation, conditionals, temporal validity) plus durable retrieval at personal scale. Most memory systems in this survey are strong at persistence + search, but weak at truth-maintenance semantics unless you add an explicit fact schema and extraction/validation pipeline.
+
+The strongest options for your constraints (offline-capable, Temporal-friendly, personal-scale cost, durable) are: **(1) PostgreSQL + pgvector + FTS + structured fact tables**, **(2) Qdrant + relational metadata/fact ledger**, and **(3) Kuzu (graph + vector + FTS) for explicit relationship/temporal reasoning**. Hosted-first options like Pinecone are technically good but weaker fit for local/offline ownership and cost control at your scale.
+
+Given Mem0 TB5 results (precision 58.8%, recall 47.6%, thread-safety issues), the architecture decision should prioritize: deterministic extraction pipeline + confidence/provenance + conflict handling, with vector DB as retrieval substrate. The retrieval store is necessary but not sufficient; your quality gains will come from schema + extraction rules + evaluation loop.
+
+## Comparison table
+| Option | Architecture | Auto fact extraction | Retrieval quality mode | Python + Temporal integration | Cost at personal scale | Durability | Key limitations | Fit (1-10) |
+|---|---|---|---|---|---|---|---|---|
+| PostgreSQL + pgvector | Relational + vector + native FTS | No (you build) | Hybrid (vector + tsvector/BM25-like ranking) | Excellent (`psycopg`, SQLAlchemy, strong transactions) | Very low self-host; managed optional | Strong WAL + PITR + ACID | You own schema/tuning | **9.2** |
+| Qdrant | Vector DB with payload filters, sparse+dense | No (you build) | Dense+sparse+RRF, strong hybrid tooling | Excellent (`qdrant-client`, async/sync) | OSS free; cloud starts free tier | WAL + snapshots + restore | Needs sidecar for rich relational logic | **8.8** |
+| Kuzu | Embedded graph DB + vector + FTS extensions | No (you build) | Graph traversal + vector + FTS | Good Python API, embeddable | OSS MIT, very low infra cost | ACID + disk persistence | Concurrency/process-mode constraints; younger ecosystem | **8.5** |
+| Weaviate | Vector-native DB with BM25/hybrid and modules | No (mostly retrieval infra) | Built-in vector/BM25 hybrid | Good Python client (v4+) | OSS/self-host or cloud from ~$25/mo | Persistent volumes + backups | Operational complexity; memory/resource planning needed | 7.8 |
+| Milvus (Lite/Standalone) | Vector DB; full-text BM25 support (not fully in Lite) | No | Vector + BM25/hybrid (deployment-dependent) | Mature `pymilvus` | OSS/self-host; managed via Zilliz | WAL-backed + object storage architecture | More ops overhead than personal-scale needs | 7.6 |
+| Neo4j (with vector indexes) | Graph DB + vector indexes | No | Graph traversal + vector semantic index | Very mature Python driver | Community free/self-host; Aura paid | ACID; managed backups in Aura tiers | Cost for managed; graph modeling overhead | 7.4 |
+| LangGraph/LangChain memory stack | Framework-level short/long-term memory APIs | Partial patterns only; not turnkey truth extraction | Depends on backing store | Excellent for workflow orchestration | Mostly OSS; store costs separate | Depends on checkpointer/store backend | Not a DB; requires backend and custom semantics | 7.2 |
+| Haystack + DocumentStore backends | Pipeline framework over many stores | No (you compose) | Sparse/dense/hybrid via backend retrievers | Strong Python integration | OSS framework; backend cost varies | Depends on backend | More RAG pipeline than personal-memory truth model | 6.8 |
+| ChromaDB | Embedded/hosted vector store | No | Semantic retrieval (+ ecosystem hybrid options) | Easy Python local use | OSS free; cloud optional | Persistent client on disk available | Production caveats + recent memory management issue report | 6.5 |
+| Pinecone (hosted) | Managed vector DB (dense/sparse/hybrid) | No | Strong semantic + hybrid | Excellent Python SDK | Free starter, paid minimums for prod tiers | Managed service + backups | No local/offline mode; cost/control mismatch for Mycel | 6.2 |
+
+## Detailed writeups
+
+## 1) PostgreSQL + pgvector (+ FTS + structured facts)
+### Name and overview
+`pgvector` is an open-source extension for PostgreSQL maintained by the pgvector project (widely adopted ecosystem). It adds vector types, operators, and ANN indexes (HNSW, IVFFlat) while preserving PostgreSQL’s transactional strengths.
+
+### Architecture
+- Core: Postgres tables for canonical facts/events.
+- Vector: `vector`/`halfvec` fields + HNSW/IVFFlat index.
+- Keyword: PostgreSQL full-text search (`tsvector`, `tsquery`, ranking).
+- Hybrid: reciprocal rank fusion or weighted blending in SQL.
+
+### Fact extraction
+No automatic extraction. Best practice for Mycel: extraction worker writes to normalized tables:
+- `facts(subject, predicate, object, truth_value, confidence, valid_from, valid_to, source_turn_id, extractor_version)`
+- `events(commitment/reminder/decision)`
+- `contradictions`/`supersessions`
+
+### Retrieval quality
+- Exact and ANN search supported.
+- Native hybrid pattern documented (vector + FTS).
+- Strong filtering, joins, temporal predicates.
+- No vendor-provided “assistant fact extraction accuracy benchmark”; quality is mostly your extraction/eval loop.
+
+### Python integration
+Excellent: `psycopg`, SQLAlchemy, async drivers, and `pgvector-python`. Easy to wrap in Temporal activities with transactional boundaries.
+
+### Cost
+Very cost-effective for 1 user/100 msgs/day. Single local Postgres instance is enough.
+
+### Durability
+Strong durability from PostgreSQL WAL/crash recovery and PITR options.
+
+### Limitations
+- Requires schema design and index tuning.
+- If extraction is weak, DB quality won’t save output quality.
+
+### Fit for Mycel
+**9.2/10**. Best balance of correctness, durability, offline capability, and Temporal-friendly transactional workflows.
+
+## 2) Qdrant
+### Name and overview
+Qdrant is an OSS vector database/semantic search engine with a mature Python client and cloud/OSS deployment options.
+
+### Architecture
+- Collections of points (vectors + payload).
+- Dense/sparse vectors in one system, plus hybrid query patterns and reranking workflows.
+- WAL-backed storage and snapshot/restore tooling.
+
+### Fact extraction
+No automatic extraction. You must implement extraction + write pipeline.
+
+### Retrieval quality
+- Strong semantic retrieval.
+- Supports sparse+dense hybrid patterns and reranking tutorials.
+- Good filtering by payload metadata.
+
+### Python integration
+Very good Python SDK (sync + async, typed models). Clean to integrate in Temporal activities.
+
+### Cost
+OSS self-host is free; managed cloud has free starter capacity and scales as needed.
+
+### Durability
+WAL + snapshots + restore mechanisms documented.
+
+### Limitations
+- Less natural for relational constraints/temporal logic than SQL-first designs.
+- You likely need relational sidecar (SQLite/Postgres) for commitments/negation state semantics.
+
+### Fit for Mycel
+**8.8/10**. Excellent retrieval engine; pair with relational fact ledger for truth/temporal correctness.
+
+## 3) Kuzu (graph + vector + FTS)
+### Name and overview
+Kuzu is an embedded graph database (MIT licensed) focused on analytical graph queries, with ACID transactions and Cypher. Recent releases added vector and FTS improvements.
+
+### Architecture
+- Embedded in-process graph DB file.
+- Extensions for vector index (HNSW) and full-text search.
+- Graph traversal useful for linked concepts and relationship-heavy memory.
+
+### Fact extraction
+No turnkey extraction. You design extraction into graph entities/edges (e.g., `:User-[:PREFERS {valid_from,...}]`), including negations and temporal validity.
+
+### Retrieval quality
+- Combines graph traversal with vector similarity and FTS.
+- Useful for explicit reasoning chains and provenance-rich queries.
+
+### Python integration
+Official Python API is straightforward. Embedded mode works well in local workflows; Temporal activities can open connections and execute Cypher transactions.
+
+### Cost
+Very low infra cost (embedded OSS).
+
+### Durability
+ACID + disk persistence.
+
+### Limitations
+- Concurrency/process mode constraints documented (careful with read-write/read-only multi-process patterns).
+- Smaller ecosystem than Postgres/Qdrant.
+
+### Fit for Mycel
+**8.5/10**. Great if you want explicit knowledge graph reasoning and are willing to own data modeling complexity.
+
+## 4) Weaviate
+### Name and overview
+Weaviate is a mature vector database platform (OSS + cloud), with integrated hybrid search features.
+
+### Architecture
+- Vector-native storage with BM25 and hybrid fusion.
+- REST/GraphQL/gRPC APIs.
+- Modules for embedding/reranking integrations.
+
+### Fact extraction
+Not a turnkey personal-memory extractor. You still build extraction/classification pipeline.
+
+### Retrieval quality
+Strong built-in hybrid (`vector + BM25`) and configurable fusion/search strategies.
+
+### Python integration
+Mature Python client (v4); async client available.
+
+### Cost
+Self-host possible; cloud serverless starts around entry paid tier.
+
+### Durability
+Persistent volume config + native backup capabilities.
+
+### Limitations
+Known-issues page is active; requires version hygiene and ops tuning. Resource planning/memory management can matter.
+
+### Fit for Mycel
+**7.8/10**. Technically strong retrieval, but heavier operational surface than needed for personal-scale assistant.
+
+## 5) Milvus (and Milvus Lite)
+### Name and overview
+Milvus is a widely used OSS vector DB; `pymilvus` includes Milvus Lite for local embedding-in-app scenarios.
+
+### Architecture
+- Vector collections, ANN indexes.
+- Full-text/BM25 + hybrid search features (availability varies by deployment; Lite has limits).
+- Cloud-native distributed architecture for larger scale.
+
+### Fact extraction
+No automatic extraction layer for personal facts.
+
+### Retrieval quality
+Strong vector retrieval; hybrid support is improving/available depending on topology and version.
+
+### Python integration
+Good with `pymilvus`, including local Lite mode.
+
+### Cost
+OSS self-host; managed via Zilliz options.
+
+### Durability
+WAL-oriented architecture and persistent storage patterns are documented in platform design notes.
+
+### Limitations
+For personal scale, can be overkill operationally compared with pgvector/Qdrant.
+
+### Fit for Mycel
+**7.6/10**. Powerful, but complexity/perf profile is better for larger workloads.
+
+## 6) Neo4j (graph + vector indexes)
+### Name and overview
+Neo4j is a mature graph database with native vector indexes and strong enterprise tooling.
+
+### Architecture
+- Property graph model with Cypher query language.
+- Vector indexes + graph traversal.
+- Managed Aura and self-managed options.
+
+### Fact extraction
+No turnkey extraction pipeline. You define schema and ingestion logic.
+
+### Retrieval quality
+Good for relationship-aware retrieval; vector search available for semantic nearest-neighbor lookups.
+
+### Python integration
+Excellent official Python driver with connection pooling.
+
+### Cost
+Community Edition is free for self-host. Aura paid tiers can be expensive relative to personal-scale needs.
+
+### Durability
+ACID transactions; managed backups on paid Aura tiers.
+
+### Limitations
+Graph modeling overhead; may be too much unless you actively exploit graph reasoning.
+
+### Fit for Mycel
+**7.4/10**. Strong if you prioritize explicit graph reasoning, weaker on cost simplicity and local lightweight operation versus Postgres/Kuzu.
+
+## 7) LangGraph/LangChain memory stack
+### Name and overview
+LangChain/LangGraph provide memory abstractions (short-term thread memory, long-term stores, checkpointers) rather than a full memory DB.
+
+### Architecture
+- Agent state + checkpointers (SQLite/Postgres/etc).
+- Optional store interface for cross-thread memory.
+- You bring your own retrieval backend and extraction logic.
+
+### Fact extraction
+Partial framework support only. No out-of-box high-accuracy negation/conditional fact extractor.
+
+### Retrieval quality
+Depends entirely on selected backing store and retrieval pipeline.
+
+### Python integration
+Excellent Python ergonomics and active ecosystem.
+
+### Cost
+OSS; backend infra determines cost.
+
+### Durability
+Depends on chosen checkpointer/store (e.g., SQLite/Postgres durable, in-memory not).
+
+### Limitations
+Framework complexity can grow quickly; abstractions may obscure state behavior unless carefully instrumented.
+
+### Fit for Mycel
+**7.2/10** as a framework layer. Valuable orchestration glue, but not enough by itself as the memory system of record.
+
+## 8) Haystack
+### Name and overview
+Haystack is an OSS Python framework for building retrieval/agent pipelines with many DocumentStore integrations.
+
+### Architecture
+- Modular pipeline components.
+- Multiple retrievers and hybrid retrievers via backend stores.
+- Integrates with pgvector, Weaviate, Pinecone, Chroma, OpenSearch, etc.
+
+### Fact extraction
+No specialized personal-memory extractor by default.
+
+### Retrieval quality
+Good building blocks for hybrid retrieval and reranking, depending on selected backend.
+
+### Python integration
+Strong and Python-native.
+
+### Cost
+Framework is OSS; costs depend on chosen storage/providers.
+
+### Durability
+Delegated to backend store.
+
+### Limitations
+More focused on RAG pipelines than persistent personal-memory truth management.
+
+### Fit for Mycel
+**6.8/10**. Useful integration layer, but not primary memory architecture.
+
+## 9) ChromaDB
+### Name and overview
+Chroma is an open-source retrieval database with local persistent client and cloud options.
+
+### Architecture
+- In-memory or persistent client on local disk.
+- Collection-based vector storage with filtering.
+
+### Fact extraction
+No automatic extraction semantics.
+
+### Retrieval quality
+Good semantic retrieval for lightweight scenarios.
+
+### Python integration
+Very easy local Python setup.
+
+### Cost
+OSS free for local use; cloud exists.
+
+### Durability
+Persistent client stores to disk and loads on startup.
+
+### Limitations
+Docs position persistent local mode as local-dev/testing oriented for production; recent issue reports highlight operational caveats in some usage patterns.
+
+### Fit for Mycel
+**6.5/10**. Fast to prototype, but lower confidence for long-lived production memory core.
+
+## 10) Pinecone (hosted)
+### Name and overview
+Pinecone is a fully managed vector database with strong hosted UX and SDKs.
+
+### Architecture
+- Serverless dense/sparse indexes.
+- Hybrid search patterns and integrated model workflows.
+- Managed backup/restore for serverless indexes.
+
+### Fact extraction
+No extraction pipeline included for your fact logic.
+
+### Retrieval quality
+Strong semantic and hybrid retrieval capabilities.
+
+### Python integration
+Mature Python SDK with async/grpc options.
+
+### Cost
+Free starter available; standard/enterprise impose monthly minimums and usage-based billing.
+
+### Durability
+Managed persistence with backup/restore features.
+
+### Limitations
+No local/offline deployment path; plan limits/minimums and cloud dependency conflict with your ownership/offline requirement.
+
+### Fit for Mycel
+**6.2/10**. Good service quality, poor alignment with local-first personal assistant requirements.
+
+## Final recommendation
+### Recommended architecture for Mycel (Phase 1)
+**Pick: PostgreSQL + pgvector + FTS, with a strict fact/event schema and extraction validator loop.**
+
+Why this wins:
+1. Best durability and correctness envelope for commitments/temporal facts.
+2. Hybrid retrieval and relational constraints in one system (no heavy multi-store complexity at MVP).
+3. Excellent Python + Temporal fit with transaction boundaries and idempotent activities.
+4. Cheapest sustainable operation at personal scale.
+5. Easiest path to later graph augmentation (Kuzu/Neo4j sidecar) without replatforming everything.
+
+### Runner-up patterns
+- Qdrant + Postgres fact ledger if you prioritize vector feature velocity.
+- Kuzu-first if graph reasoning is core from day 1.
+
+## Implementation sketch (top choice)
+### Phase 1 goals
+- Durable storage of extracted facts/events.
+- High-precision extraction for critical classes: preferences, commitments, decisions, constraints.
+- Hybrid retrieval for question answering.
+- Temporal correctness and negation support.
+
+### Data model (minimal)
+```sql
+-- canonical source of truth for raw conversation turns
+CREATE TABLE convo_turns (
+  id BIGSERIAL PRIMARY KEY,
+  convo_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- normalized memory facts
+CREATE TABLE memory_facts (
+  id BIGSERIAL PRIMARY KEY,
+  subject TEXT NOT NULL,
+  predicate TEXT NOT NULL,
+  object_text TEXT NOT NULL,
+  truth_value TEXT NOT NULL CHECK (truth_value IN ('true','false','conditional','unknown')),
+  condition_text TEXT,
+  valid_from TIMESTAMPTZ,
+  valid_to TIMESTAMPTZ,
+  confidence REAL NOT NULL,
+  source_turn_id BIGINT NOT NULL REFERENCES convo_turns(id),
+  extractor_version TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  embedding VECTOR(1536)
+);
+
+CREATE INDEX ON memory_facts USING hnsw (embedding vector_cosine_ops);
+
+-- keyword/hybrid search support
+ALTER TABLE memory_facts ADD COLUMN fts tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(subject,'') || ' ' || coalesce(predicate,'') || ' ' || coalesce(object_text,''))
+  ) STORED;
+CREATE INDEX memory_facts_fts_idx ON memory_facts USING GIN (fts);
+```
+
+### Retrieval query pattern
+```sql
+-- pseudo: vector top-k + keyword top-k then fuse in app layer
+-- vector
+SELECT id, 1 - (embedding <=> :query_vec) AS sem_score
+FROM memory_facts
+WHERE (valid_to IS NULL OR valid_to > now())
+ORDER BY embedding <=> :query_vec
+LIMIT 30;
+
+-- keyword
+SELECT id, ts_rank_cd(fts, plainto_tsquery('english', :q)) AS kw_score
+FROM memory_facts
+WHERE fts @@ plainto_tsquery('english', :q)
+  AND (valid_to IS NULL OR valid_to > now())
+ORDER BY kw_score DESC
+LIMIT 30;
+```
+
+### Temporal workflow decomposition (Python)
+1. `IngestTurnWorkflow`: store raw turn.
+2. `ExtractFactsActivity` (cheap model): produce candidate facts + negation/conditional flags.
+3. `ValidateFactsActivity` (rules + optional stronger model): reject low-confidence or contradictory outputs.
+4. `UpsertFactsActivity` (transaction): write facts with provenance, set superseded facts `valid_to`.
+5. `RetrieveContextActivity`: hybrid search + temporal filtering + top-N selection.
+
+### Guardrails to address TB5 failure modes
+- Mandatory `truth_value` (`true/false/conditional`) and explicit `condition_text`.
+- Temporal normalization (`valid_from`, `valid_to`, “next Friday” resolution timestamped with locale).
+- Multi-fact utterance splitting with atomic inserts per fact.
+- Contradiction detector for same `(subject, predicate)` with incompatible objects.
+- Evaluation harness using your TB5 dataset on every extractor/prompt change.
+
+## Sources
+- Qdrant docs: https://qdrant.tech/documentation/overview/
+- Qdrant storage/WAL: https://qdrant.tech/documentation/concepts/storage/
+- Qdrant snapshots: https://qdrant.tech/documentation/concepts/snapshots/
+- Qdrant Python client: https://python-client.qdrant.tech/index.html
+- Qdrant pricing: https://qdrant.tech/pricing/
+- Qdrant hybrid guides: https://qdrant.tech/documentation/advanced-tutorials/reranking-hybrid-search/
+- pgvector README: https://github.com/pgvector/pgvector
+- pgvector Python: https://github.com/pgvector/pgvector-python
+- PostgreSQL WAL reliability: https://www.postgresql.org/docs/current/wal-reliability.html
+- PostgreSQL FTS intro: https://www.postgresql.org/docs/10/textsearch-intro.html
+- PostgreSQL PITR: https://www.postgresql.org/docs/14/continuous-archiving.html
+- Weaviate hybrid search: https://docs.weaviate.io/weaviate/search/hybrid
+- Weaviate Python client: https://docs.weaviate.io/weaviate/client-libraries/python
+- Weaviate persistence: https://docs.weaviate.io/deploy/configuration/persistence
+- Weaviate known issues: https://docs.weaviate.io/weaviate/release-notes/known-issues
+- Weaviate pricing: https://weaviate.io/pricing/
+- Milvus quickstart: https://milvus.io/docs/quickstart.md/
+- Milvus PyMilvus install: https://milvus.io/docs/install-pymilvus.md/
+- Milvus full text search: https://milvus.io/docs/embed-with-bm25.md
+- Neo4j vector indexes: https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/
+- Neo4j Python driver: https://neo4j.com/docs/api/python-driver/current/api.html
+- Neo4j pricing: https://neo4j.com/pricing/
+- Kuzu docs overview: https://kuzudb.com/docs
+- Kuzu vector extension: https://docs.kuzudb.com/extensions/vector/
+- Kuzu FTS extension: https://docs.kuzudb.com/extensions/full-text-search/
+- Kuzu concurrency notes: https://kuzudb.com/docs/concurrency
+- LangChain short-term memory: https://docs.langchain.com/oss/python/langchain/short-term-memory
+- LangGraph persistence/checkpointers: https://docs.langchain.com/oss/python/langgraph/persistence
+- LangGraph add memory: https://docs.langchain.com/oss/python/langgraph/add-memory
+- LlamaIndex memory: https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/memory/
+- LlamaIndex chat stores: https://docs.llamaindex.ai/en/stable/module_guides/storing/chat_stores/
+- Haystack install/docs: https://docs.haystack.deepset.ai/docs/installation
+- Haystack retrievers: https://docs.haystack.deepset.ai/docs/retrievers
+- Haystack pgvector store: https://docs.haystack.deepset.ai/docs/pgvectordocumentstore
+- Chroma clients/persistence: https://docs.trychroma.com/docs/run-chroma/clients
+- Chroma Python reference: https://docs.trychroma.com/reference/python
+- Chroma issue example (memory management caveat): https://github.com/chroma-core/chroma/issues/5843
+- Pinecone hybrid search: https://docs.pinecone.io/guides/search/hybrid-search
+- Pinecone Python SDK: https://docs.pinecone.io/reference/sdks/python/overview
+- Pinecone limits: https://docs.pinecone.io/docs/limits
+- Pinecone pricing: https://www.pinecone.io/pricing/
+- Pinecone backups: https://docs.pinecone.io/guides/indexes/understanding-backups
+- SQLite FTS5: https://www.sqlite.org/fts5.html
+- sqlite-vec: https://alexgarcia.xyz/sqlite-vec/

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,8 @@
+# Reports
+
+Reference docs produced during Mycel research/tracer-bullet phase.
+
+## 2026-02-21
+- **Claude-mem analysis** — [`2026-02-21-claude-mem-analysis.md`](2026-02-21-claude-mem-analysis.md)
+- **LLM memory systems survey** — [`2026-02-21-llm-memory-systems-survey.md`](2026-02-21-llm-memory-systems-survey.md)
+- **Mycel memory research (options + recommendation)** — [`2026-02-21-mycel-memory-research.md`](2026-02-21-mycel-memory-research.md)


### PR DESCRIPTION
Adds a permanent home for generated research reports (claude-mem analysis, memory systems survey, memory options research) under docs/reports/ with an index.